### PR TITLE
Dungeon Air Lag Fix

### DIFF
--- a/_maps/map_files/generic/z5dungeon.dmm
+++ b/_maps/map_files/generic/z5dungeon.dmm
@@ -3,9 +3,9 @@
 "c" = (/turf/indestructible/bedrock,/area/dungeon)
 "d" = (/turf/simulated/mineral/random,/area/dungeon)
 "e" = (/turf/indestructible/dungeon/iron,/area/dungeon)
-"f" = (/obj/structure/mineral_door/iron,/turf/simulated/floor/plasteel/rockvault,/area/dungeon)
-"g" = (/turf/simulated/floor/plasteel/rockvault,/area/dungeon)
-"h" = (/obj/structure/ladder{anchored = 1; height = 0; id = "vault_dungeon"},/turf/simulated/floor/plasteel/rockvault,/area/dungeon)
+"f" = (/obj/structure/mineral_door/iron,/turf/simulated/floor/plasteel/rockvault{nitrogen = 0; oxygen = 0; temperature = 0},/area/dungeon)
+"g" = (/turf/simulated/floor/plasteel/rockvault{nitrogen = 0; oxygen = 0; temperature = 0},/area/dungeon)
+"h" = (/obj/structure/ladder{anchored = 1; height = 0; id = "vault_dungeon"},/turf/simulated/floor/plasteel/rockvault{nitrogen = 0; oxygen = 0; temperature = 0},/area/dungeon)
 
 (1,1,1) = {"
 aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa

--- a/code/modules/mining/mine_turfs.dm
+++ b/code/modules/mining/mine_turfs.dm
@@ -511,8 +511,8 @@ var/global/list/rockTurfEdgeCache
 	var/dug = 0       //0 = has not yet been dug, 1 = has already been dug
 
 /turf/simulated/floor/plating/asteroid/airless
-	oxygen = 0.01
-	nitrogen = 0.01
+	oxygen = 0.0
+	nitrogen = 0.0
 	temperature = TCMB
 
 /turf/simulated/floor/plating/asteroid/New()


### PR DESCRIPTION
Fixes the ~7000 active turfs created when someone enters the dungeon and tries mining it.